### PR TITLE
Thang/fix mlflow

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -54,6 +54,7 @@ from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 # Initialize MLFlow
 import mlflow
+mlflow.set_tracking_uri(str(os.environ.get("TRACKING_URI")))
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -580,7 +581,6 @@ def main():
     os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
     os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
     os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
-    os.environ["MLFLOW_TRACKING_URI"]=str(os.environ.get("TRACKING_URI"))
 
     # Training
     if training_args.do_train:

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -628,7 +628,7 @@ def main():
             kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
-
+    mlflow.end_run()
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)
     else:

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -52,7 +52,8 @@ from transformers.testing_utils import CaptureLogger
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
-
+# Initialize MLFlow
+import mlflow
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -572,6 +573,14 @@ def main():
         if training_args.do_eval and not is_torch_tpu_available()
         else None,
     )
+    # Mlflow initial
+    experiment_name =f'language-modeling-clm-{model_args.model_name_or_path}'
+    #set the os enviroment for MLflowCallback
+    os.environ["DISABLE_MLFLOW_INTEGRATION"] = "False"
+    os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
+    os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
+    os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
+    os.environ["MLFLOW_TRACKING_URI"]=str(os.environ.get("TRACKING_URI"))
 
     # Training
     if training_args.do_train:

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -51,7 +51,9 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 # Initialize MLFlow
+# Initialize MLFlow
 import mlflow
+mlflow.set_tracking_uri(str(os.environ.get("TRACKING_URI")))
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -606,7 +608,6 @@ def main():
     os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
     os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
     os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
-    os.environ["MLFLOW_TRACKING_URI"]=str(os.environ.get("TRACKING_URI"))
 
     # Training
     if training_args.do_train:

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -653,7 +653,7 @@ def main():
             kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
-
+    mlflow.end_run()
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)
     else:

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -50,7 +50,8 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
-
+# Initialize MLFlow
+import mlflow
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -597,6 +598,15 @@ def main():
         if training_args.do_eval and not is_torch_tpu_available()
         else None,
     )
+
+    # Mlflow initial
+    experiment_name =f'language-modeling-mlm-{model_args.model_name_or_path}'
+    #set the os enviroment for MLflowCallback
+    os.environ["DISABLE_MLFLOW_INTEGRATION"] = "False"
+    os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
+    os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
+    os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
+    os.environ["MLFLOW_TRACKING_URI"]=str(os.environ.get("TRACKING_URI"))
 
     # Training
     if training_args.do_train:

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -44,7 +44,8 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
-
+# Initialize MLFlow
+import mlflow
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -509,6 +510,15 @@ def main():
         tokenizer=tokenizer,
         data_collator=data_collator,
     )
+
+    # Mlflow initial
+    experiment_name =f'language-modeling-plm-{model_args.model_name_or_path}'
+    #set the os enviroment for MLflowCallback
+    os.environ["DISABLE_MLFLOW_INTEGRATION"] = "False"
+    os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
+    os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
+    os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
+    os.environ["MLFLOW_TRACKING_URI"]=str(os.environ.get("TRACKING_URI"))
 
     # Training
     if training_args.do_train:

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -565,7 +565,7 @@ def main():
             kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
-
+    mlflow.end_run()
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)
     else:

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -46,6 +46,7 @@ from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 # Initialize MLFlow
 import mlflow
+mlflow.set_tracking_uri(str(os.environ.get("TRACKING_URI")))
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -518,7 +519,6 @@ def main():
     os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
     os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
     os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
-    os.environ["MLFLOW_TRACKING_URI"]=str(os.environ.get("TRACKING_URI"))
 
     # Training
     if training_args.do_train:

--- a/examples/pytorch/language-modeling/train_clm.sh
+++ b/examples/pytorch/language-modeling/train_clm.sh
@@ -33,6 +33,9 @@ args="
 --block_size 1024 \
 --overwrite_cache True \
 --overwrite_output_dir \
+--logging_strategy epoch \
+--save_total_limit 2 \
+--num_train_epochs 3 \
 "
 
 python3 run_clm.py \

--- a/examples/pytorch/language-modeling/train_clm.sh
+++ b/examples/pytorch/language-modeling/train_clm.sh
@@ -29,6 +29,10 @@ args="
 --dataset_config_name wikitext-2-raw-v1 \
 --do_train \
 --do_eval \
+--torch_dtype float32 \
+--block_size 1024 \
+--overwrite_cache True \
+--overwrite_output_dir \
 "
 
 python3 run_clm.py \

--- a/examples/pytorch/language-modeling/train_mlm.sh
+++ b/examples/pytorch/language-modeling/train_mlm.sh
@@ -26,6 +26,9 @@ args="
 --do_train \
 --do_eval \
 --overwrite_output_dir \
+--logging_strategy epoch \
+--save_total_limit 2 \
+--num_train_epochs 3 \
 "
 
 ## Using moreh device

--- a/examples/pytorch/language-modeling/train_plm.sh
+++ b/examples/pytorch/language-modeling/train_plm.sh
@@ -25,6 +25,10 @@ args="
 --validation_file path_to_validation_file \
 --do_train \
 --do_eval \
+--overwrite_output_dir \
+--logging_strategy epoch \
+--save_total_limit 2 \
+--num_train_epochs 3 \
 "
 
 python3 run_plm.py \


### PR DESCRIPTION
Apparently, HF trainer has a callback already include mlflow. Therefore I modify the code using their callback.
# What does this PR do?

-Set the TRACKING_URI to environment variable as default value: http://127.0.0.1:5000/  so we can change them if needed 
-set the experiment name to f-string 
-allow log artifact (can be disable for faster training time)