### PR TITLE
Log number of parameters of a model

### DIFF
--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -218,6 +218,14 @@ class DataTrainingArguments:
                 assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def main():
     # See all possible arguments in src/transformers/training_args.py
     # or by passing the --help flag to this script.
@@ -392,6 +400,9 @@ def main():
         logger.info("Training new model from scratch")
         model = XLNetLMHeadModel(config)
 
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
+
     # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
     # on a small vocab and want a smaller embedding size, remove this test.
     embedding_size = model.get_input_embeddings().weight.shape[0]
@@ -519,6 +530,7 @@ def main():
     os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
     os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
     os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
+
 
     # Training
     if training_args.do_train:


### PR DESCRIPTION
Background
We currently include the size information in the model name and use it to differentiate between model sizes. However, I think it's too hard to tell what size this model is with a size name like '-base', '-large', '-b0' etc.

Even, nowadays, the number of parameters, such as 7b, is used as a suffix to express the size of the model. This numbering tells us more information. How much GPU memory usage will be occupied when a model is loaded. It also makes it easier to compare model sizes between similar types of models, such as trasnformers models.

What this PR does
- calculate the number of parameters of a model and log using mlflow.log_param().
