### PR TITLE
Thang/remove mlflow from train script

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -586,10 +586,8 @@ def main():
     )
 
     # Mlflow initial
-    experiment_name =f'language-modeling-plm-{model_args.model_name_or_path}'
     #set the os enviroment for MLflowCallback
     os.environ["DISABLE_MLFLOW_INTEGRATION"] = "False"
-    os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
     os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="False"
     os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
 

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -52,6 +52,8 @@ from transformers.testing_utils import CaptureLogger
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
+# Initialize MLFlow
+import mlflow
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -222,6 +224,15 @@ class DataTrainingArguments:
             if self.validation_file is not None:
                 extension = self.validation_file.split(".")[-1]
                 assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
+
+# Log number of parameters function
+def get_num_parameters(model):
+    num_params = 0
+    for param in model.parameters():
+        num_params += param.numel()
+    # in million
+    num_params /= 10**6
+    return num_params
 
 def main():
     # See all possible arguments in src/transformers/training_args.py
@@ -421,6 +432,9 @@ def main():
         model = AutoModelForCausalLM.from_config(config)
         n_params = sum({p.data_ptr(): p.numel() for p in model.parameters()}.values())
         logger.info(f"Training new model from scratch - Total size={n_params/2**20:.2f}M params")
+    # Log number of parameters
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
 
     # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
     # on a small vocab and want a smaller embedding size, remove this test.
@@ -571,6 +585,14 @@ def main():
         else None,
     )
 
+    # Mlflow initial
+    experiment_name =f'language-modeling-plm-{model_args.model_name_or_path}'
+    #set the os enviroment for MLflowCallback
+    os.environ["DISABLE_MLFLOW_INTEGRATION"] = "False"
+    os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
+    os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="False"
+    os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
+
     # Training
     if training_args.do_train:
         checkpoint = None
@@ -619,7 +641,7 @@ def main():
             kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
-
+    mlflow.end_run()
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)
     else:

--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -44,9 +44,7 @@ from transformers import (
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
-# Initialize MLFlow
-import mlflow
-mlflow.set_tracking_uri(str(os.environ.get("TRACKING_URI")))
+
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.29.0")
@@ -512,14 +510,6 @@ def main():
         data_collator=data_collator,
     )
 
-    # Mlflow initial
-    experiment_name =f'language-modeling-plm-{model_args.model_name_or_path}'
-    #set the os enviroment for MLflowCallback
-    os.environ["DISABLE_MLFLOW_INTEGRATION"] = "False"
-    os.environ["MLFLOW_EXPERIMENT_NAME"]=experiment_name
-    os.environ["HF_MLFLOW_LOG_ARTIFACTS"]="True"
-    os.environ["MLFLOW_FLATTEN_PARAMS"]="True"
-
     # Training
     if training_args.do_train:
         checkpoint = None
@@ -567,7 +557,7 @@ def main():
             kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
-    mlflow.end_run()
+
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)
     else:


### PR DESCRIPTION
- Remove mlflow code in run_plm script due to the error when run the script by model runner.
- The error maybe caused by re-define the tracking uri in the script. To test my theory, I move the mlflow code to run_clm and add the log parameters.