### PR TITLE
Add mlfow log evaluate metrics

### DIFF
--- a/examples/pytorch/language-modeling/run_plm.py
+++ b/examples/pytorch/language-modeling/run_plm.py
@@ -242,6 +242,13 @@ class TBTrainerCallback(TrainerCallback):
                 mlflow.log_metric("throughput", throughput , step=state.global_step)
                 print(f'loss: {state.log_history[-1]["loss"]}, lr: {state.log_history[-1]["learning_rate"]}, throughput: {throughput}, step: {state.global_step}')       
 
+    def on_evaluate(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        try:
+            perplexity = math.exp(state.log_history[-1]["eval_loss"])
+        except OverflowError:
+            perplexity = float("inf")
+        mlflow.log_metric("perplexity",perplexity)
+
 # Log number of parameters function
 def get_num_parameters(model):
     num_params = 0

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -232,12 +232,18 @@ class TBTrainerCallback(TrainerCallback):
             throughput = num_samples / logging_step_runtime
             if 'loss' in state.log_history[-1]:
                 state.log_history[-1]["throughput"] = throughput
-                state.log_history[-1]["step"] = state.global_step
-
+                state.log_history[-1]["step"] = state.global_step              
                 mlflow.log_metric("lr", state.log_history[-1]["learning_rate"] , step=state.global_step)
                 mlflow.log_metric("throughput", throughput , step=state.global_step)
                 print(f'loss: {state.log_history[-1]["loss"]}, lr: {state.log_history[-1]["learning_rate"]}, throughput: {throughput}, step: {state.global_step}')       
-
+    
+    def on_evaluate(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        # breakpoint()
+        eval_exact_match = 0. if state.log_history[-1]["eval_exact_match"] is None else state.log_history[-1]["eval_exact_match"]
+        eval_f1 = 0. if state.log_history[-1]["eval_f1"] is None else state.log_history[-1]["eval_f1"]
+        mlflow.log_metric("eval_exact_match",eval_exact_match)
+        mlflow.log_metric("eval_f1",eval_f1)
+        return super().on_evaluate(args, state, control, **kwargs)
 # Log number of parameters function
 def get_num_parameters(model):
     num_params = 0

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -238,12 +238,11 @@ class TBTrainerCallback(TrainerCallback):
                 print(f'loss: {state.log_history[-1]["loss"]}, lr: {state.log_history[-1]["learning_rate"]}, throughput: {throughput}, step: {state.global_step}')       
     
     def on_evaluate(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        # breakpoint()
         eval_exact_match = 0. if state.log_history[-1]["eval_exact_match"] is None else state.log_history[-1]["eval_exact_match"]
         eval_f1 = 0. if state.log_history[-1]["eval_f1"] is None else state.log_history[-1]["eval_f1"]
         mlflow.log_metric("eval_exact_match",eval_exact_match)
         mlflow.log_metric("eval_f1",eval_f1)
-        return super().on_evaluate(args, state, control, **kwargs)
+        
 # Log number of parameters function
 def get_num_parameters(model):
     num_params = 0


### PR DESCRIPTION
# Background
Some task don't have eval criterion need for Accuracy and Performance Tests.

# What does this PR do?
Modify the callback for mlflow to log eval metric:
- perplexity for 'permuted language modeling' task
- eval_f1 for 'question answering' task