### PR TITLE
Update setuptools to 69.5.1

### DIFF
--- a/requirements.moreh.txt
+++ b/requirements.moreh.txt
@@ -3,7 +3,7 @@ accelerate==0.21.0
 pandas==2.0.3
 sacremoses==0.0.53
 sacrebleu==2.3.1
-setuptools==65.5.0
+setuptools==69.5.1
 scipy==1.10.1
 soundfile==0.12.1
 fsspec==2023.9.2


### PR DESCRIPTION
## Background
Our latest `moreh_driver` (version 24.8.3020) on Nexus requires `setuptools` version `69.5.1`. However, our benchmarks are currently using `setuptools` version `65.5.0`, as specified in our `requirements.moreh.txt` file, which is causing compatibility issues.

## Contents
- Update `setuptools` to `69.5.1`.