### PR TITLE
[MAF-18899] Apply Gradient Checkpoint Config

### DIFF
--- a/src/transformers/models/gpt2/modeling_gpt2_moreh.py
+++ b/src/transformers/models/gpt2/modeling_gpt2_moreh.py
@@ -1028,10 +1028,9 @@ class GPT2Model(GPT2PreTrainedModel):
         # If moreh_gradient_checkpoint_layers_step is N,
         # then 1st, (1+N)th, (1+2N)th, ... layer's input activations will be checkpointed
         self.moreh_gradient_checkpoint_layers_step = None
-        if self.moreh_gradient_checkpoint_layers_step is not None and (
-                layer_idx %
-                self.moreh_gradient_checkpoint_layers_step) == 0:
-            hidden_states = torch.moreh.checkpoint_assign(hidden_states)
+        if moreh_config is not None and "gradient_checkpoint_layers_step" in moreh_config:
+            self.moreh_gradient_checkpoint_layers_step = moreh_config[
+                "gradient_checkpoint_layers_step"]
 
     @add_start_docstrings(PARALLELIZE_DOCSTRING)
     def parallelize(self, device_map=None):
@@ -1224,7 +1223,7 @@ class GPT2Model(GPT2PreTrainedModel):
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
             # Gradient checkpoint assign
             if self.moreh_gradient_checkpoint_layers_step is not None and (
-                    layer_idx %
+                    i %
                     self.moreh_gradient_checkpoint_layers_step) == 0:
                 hidden_states = torch.moreh.checkpoint_assign(hidden_states)
 

--- a/src/transformers/models/gpt2/modeling_gpt2_moreh.py
+++ b/src/transformers/models/gpt2/modeling_gpt2_moreh.py
@@ -1017,11 +1017,21 @@ class GPT2Model(GPT2PreTrainedModel):
         self.post_init()
 
         # Moreh Config
-        self.moreh_pipeline_layers = []
         moreh_config = getattr(config, "moreh_config", None)
+
+        # Moreh Pipeline Layers
+        self.moreh_pipeline_layers = []
         if moreh_config is not None and "pipeline_layers" in moreh_config:
             self.moreh_pipeline_layers = moreh_config["pipeline_layers"]
 
+        # Moreh Gradient Checkpoint Layers Step
+        # If moreh_gradient_checkpoint_layers_step is N,
+        # then 1st, (1+N)th, (1+2N)th, ... layer's input activations will be checkpointed
+        self.moreh_gradient_checkpoint_layers_step = None
+        if self.moreh_gradient_checkpoint_layers_step is not None and (
+                layer_idx %
+                self.moreh_gradient_checkpoint_layers_step) == 0:
+            hidden_states = torch.moreh.checkpoint_assign(hidden_states)
 
     @add_start_docstrings(PARALLELIZE_DOCSTRING)
     def parallelize(self, device_map=None):
@@ -1212,6 +1222,12 @@ class GPT2Model(GPT2PreTrainedModel):
         all_cross_attentions = () if output_attentions and self.config.add_cross_attention else None
         all_hidden_states = () if output_hidden_states else None
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
+            # Gradient checkpoint assign
+            if self.moreh_gradient_checkpoint_layers_step is not None and (
+                    layer_idx %
+                    self.moreh_gradient_checkpoint_layers_step) == 0:
+                hidden_states = torch.moreh.checkpoint_assign(hidden_states)
+
             # Model parallel
             if self.model_parallel:
                 torch.cuda.set_device(hidden_states.device)

--- a/src/transformers/models/mistral/modeling_mistral_moreh.py
+++ b/src/transformers/models/mistral/modeling_mistral_moreh.py
@@ -930,10 +930,9 @@ class MistralModel(MistralPreTrainedModel):
         # If moreh_gradient_checkpoint_layers_step is N,
         # then 1st, (1+N)th, (1+2N)th, ... layer's input activations will be checkpointed
         self.moreh_gradient_checkpoint_layers_step = None
-        if self.moreh_gradient_checkpoint_layers_step is not None and (
-                layer_idx %
-                self.moreh_gradient_checkpoint_layers_step) == 0:
-            hidden_states = torch.moreh.checkpoint_assign(hidden_states)
+        if moreh_config is not None and "gradient_checkpoint_layers_step" in moreh_config:
+            self.moreh_gradient_checkpoint_layers_step = moreh_config[
+                "gradient_checkpoint_layers_step"]
 
     def get_input_embeddings(self):
         return self.embed_tokens
@@ -1008,6 +1007,12 @@ class MistralModel(MistralPreTrainedModel):
         next_decoder_cache = None
 
         for layer_idx, decoder_layer in enumerate(self.layers):
+            # Gradient checkpoint assign
+            if self.moreh_gradient_checkpoint_layers_step is not None and (
+                    layer_idx %
+                    self.moreh_gradient_checkpoint_layers_step) == 0:
+                hidden_states = torch.moreh.checkpoint_assign(hidden_states)
+
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/mistral/modeling_mistral_moreh.py
+++ b/src/transformers/models/mistral/modeling_mistral_moreh.py
@@ -919,10 +919,21 @@ class MistralModel(MistralPreTrainedModel):
         self.post_init()
 
         # Moreh Config
-        self.moreh_pipeline_layers = []
         moreh_config = getattr(config, "moreh_config", None)
+
+        # Moreh Pipeline Layers
+        self.moreh_pipeline_layers = []
         if moreh_config is not None and "pipeline_layers" in moreh_config:
             self.moreh_pipeline_layers = moreh_config["pipeline_layers"]
+
+        # Moreh Gradient Checkpoint Layers Step
+        # If moreh_gradient_checkpoint_layers_step is N,
+        # then 1st, (1+N)th, (1+2N)th, ... layer's input activations will be checkpointed
+        self.moreh_gradient_checkpoint_layers_step = None
+        if self.moreh_gradient_checkpoint_layers_step is not None and (
+                layer_idx %
+                self.moreh_gradient_checkpoint_layers_step) == 0:
+            hidden_states = torch.moreh.checkpoint_assign(hidden_states)
 
     def get_input_embeddings(self):
         return self.embed_tokens


### PR DESCRIPTION
# PR description

pipeline_assign 과 비슷하게, gradient checkpoint 를 어느 시점에 해줄 지 `torch.moreh.checkpoint_assign()` 을 통해 할 수 있다. 이를 GPT2, Mistral 코드에 적용하였다.

Moreh framework 의 https://github.com/moreh-dev/framework/commit/744f3476de06509ddcd7382928b971134c00d9d2#diff-fd7e20039cc03d4c907ed4ec098d41a9e74fe6db7423e80aca8cd54888a3a8fa 커밋 참고.

관련 Jira issue link: https://moreh.atlassian.net/browse/MAF-18899
